### PR TITLE
Migrated out pydantic models to keep api.py clean and focused primari…

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,12 +1,11 @@
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
 import adalflow as adal
 from src.rag import RAG
-from typing import List, Optional
 import os
 from dotenv import load_dotenv
 from datetime import datetime, timezone
+from pydantic_models import *
 
 def load_environment():
     """Load environment variables from .env file if available, otherwise use system environment variables."""
@@ -58,26 +57,6 @@ try:
 except Exception as e:
     print(f"Error initializing RAG component: {e}")
     raise RuntimeError(f"Failed to initialize RAG component: {e}")
-
-class QueryRequest(BaseModel):
-    repo_url: str
-    query: str
-
-class DocumentMetadata(BaseModel):
-    file_path: str
-    type: str
-    is_code: bool = False
-    is_implementation: bool = False
-    title: str = ""
-
-class Document(BaseModel):
-    text: str
-    meta_data: DocumentMetadata
-
-class QueryResponse(BaseModel):
-    rationale: str
-    answer: str
-    contexts: List[Document]
 
 @app.post("/query", response_model=QueryResponse)
 async def query_repository(request: QueryRequest):

--- a/pydantic_models/__init__.py
+++ b/pydantic_models/__init__.py
@@ -1,0 +1,13 @@
+from .models import (
+    QueryRequest,
+    QueryResponse,
+    Document,
+    DocumentMetadata
+)
+
+__all__ = [
+    "QueryRequest",
+    "QueryResponse",
+    "Document",
+    "DocumentMetadata"
+]

--- a/pydantic_models/models.py
+++ b/pydantic_models/models.py
@@ -1,0 +1,38 @@
+from pydantic import BaseModel
+from typing import List
+
+class QueryRequest(BaseModel):
+    repo_url: str
+    query: str
+
+class DocumentMetadata(BaseModel):
+    file_path: str
+    type: str
+    is_code: bool = False
+    is_implementation: bool = False
+    title: str = ""
+
+# Consider extending what metadata is tracked in DoumentMetaData
+# or create an additional class. I think it could be important to track other
+# metadata metrics, such as line count and file size.
+
+# Justification: 
+# During the EDA stages of model improvement, tracking repo sizes, file sizes, line counts
+# could reveal relationships between performance.
+
+class Document(BaseModel):
+    text: str
+    meta_data: DocumentMetadata
+
+class QueryResponse(BaseModel):
+    rationale: str
+    answer: str
+    contexts: List[Document]
+
+
+__all__ = [
+    "QueryReqest",
+    "QueryResponse",
+    "Document",
+    "DocumentMetadata"
+]


### PR DESCRIPTION
…ly on API logic. Pydantic models will now be located under /pydantic_models nad imported as from pydantic_models import *